### PR TITLE
Dockerのビルド時にpip installをコード代入より前に実行する．

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,16 @@ RUN  sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /et
 
 RUN useradd -m -s /bin/bash zaim
 
-COPY ./pyzaim /home/zaim/pyzaim
-COPY main.py  /home/zaim/main.py
-COPY requirements.txt /home/zaim/requirements.txt
-
-RUN chown -R zaim:zaim /home/zaim/
 
 USER zaim
 
 WORKDIR /home/zaim/
 
+COPY requirements.txt /home/zaim/requirements.txt
+
 RUN pip install -r requirements.txt
+
+COPY ./pyzaim /home/zaim/pyzaim
+COPY main.py  /home/zaim/main.py
 
 ENTRYPOINT ["./main.py"]


### PR DESCRIPTION
Fixes #6